### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Panino is an API documentation generation tool. It can read comments from your source files, or, parse Markdown files and generate the same documentation. Panino runs on [Node.js](http://www.nodejs.org), and uses [Jade](http://jade-lang.com/) as its templating engine.
 
-Panino parses your content following a strict, no-crap-allowed grammar that ensures **correct** and **consistent** documentation, because you've written it following a specific syntax. This means that there is a very specific set of rules and expectations as to how to write your documentation. These rules are not terribly hard or unweildly. Keeping documentation parsed through a grammar ensures thorough and consistent docs, no matter who it's written by. It can parse your source files in two ways:
+Panino parses your content following a strict, no-crap-allowed grammar that ensures **correct** and **consistent** documentation, because you've written it following a specific syntax. This means that there is a very specific set of rules and expectations as to how to write your documentation. These rules are not terribly hard or unwieldy. Keeping documentation parsed through a grammar ensures thorough and consistent docs, no matter who it's written by. It can parse your source files in two ways:
 
 1. By using the [pdoc](https://github.com/tobie/pdoc)-notation for documentation. [This blog post](http://andrewdupont.net/2008/11/16/pdoc-inline-documentation-for-prototype/) identifies some of the advantages over other commenting-to-documentation systems.  The pdoc system was originally based on [ndoc](https://github.com/nodeca/ndoc).)
 2. By using a JSDoc-like notation for comments. The inspiration and much of the work for this parsing comes from a port of [JSDuck](https://github.com/senchalabs/jsduck). While some of the conventions of JSDuck are kept, this should not be considered a 100% port.
@@ -19,10 +19,10 @@ For more help, including syntax and tag definitions, see [the wiki](https://gith
 * Support for Markdown files
 * Creating a separate page for every class
 * Support for proper "`[[ ]]`"-notation linking (_e.g. `[[Class.foo]]` renders to a link wrapped in a `<code>` tag)
-* Adding "shortened" descriptions, truncating the full description into a single sentance
+* Adding "shortened" descriptions, truncating the full description into a single sentence
 * Ability to linkify everything (object types in signatures, return types, e.t.c.)
 * Allowing to specify a URL to retrieve documentation about global objects (like `Array` or `String`)
-* Support for [content references (or conrefs)](http://www.github.com/gjtorikian/markdown_conrefs). Conrefs are a way to write a sentance once, and refer to it in multiple locations. 
+* Support for [content references (or conrefs)](http://www.github.com/gjtorikian/markdown_conrefs). Conrefs are a way to write a sentence once, and refer to it in multiple locations. 
 * Documentation runs through [a test suite](https://github.com/gjtorikian/functional-docs) to ensure the validity of all links and images
 * Support for arbitrary metadata on classes and members (that can be used in templates)
 * Support for arbitrary Markdown-to-HTML page conversion
@@ -31,7 +31,7 @@ Markdown is converted using [namp](https://github.com/gjtorikian/namp).
 
 # Installation
 
-You'll need `node.js` and `npm` installed. Then, you can can choose to install Panino globally:
+You'll need `node.js` and `npm` installed. Then, you can choose to install Panino globally:
 
     npm install -g panino
 
@@ -91,7 +91,7 @@ Panino has two processes: a parsing phase, and a rendering phase.
 
 # Reporting
 
-Panino also supports reporting methods that are missing documentation. Currently, this is only supproted for `"jsd"`-style parsing. There are two ways to report missing documentation:
+Panino also supports reporting methods that are missing documentation. Currently, this is only supported for `"jsd"`-style parsing. There are two ways to report missing documentation:
 
 * By passing in `report: true`, Panino will print out a list of missing methods in a class, along with a percentage indicating the overall coverage.
 * By passing in `reportOnly: true`, Panino's `parse()` will return a `reportObject` instead of an `ast`, as the second argument in the callback. You can then take this object and iterate over it any way you choose.


### PR DESCRIPTION
Found a few typos in the readme -
`unweildly` → `unwieldy`
`sentance` → `sentence`
Remove extra `can`
`supproted` → `supported`
